### PR TITLE
Fix: Corrige o namespace do AbstractPluginBundle

### DIFF
--- a/plugins/HubObjectsBundle/HubObjectsBundle.php
+++ b/plugins/HubObjectsBundle/HubObjectsBundle.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace MauticPlugin\HubObjectsBundle;
 
-use MauticPlugin\IntegrationsBundle\Bundle\AbstractPluginBundle;
+use Mautic\IntegrationsBundle\Bundle\AbstractPluginBundle;
 
 class HubObjectsBundle extends AbstractPluginBundle
 {


### PR DESCRIPTION
O namespace para a importação da classe AbstractPluginBundle estava incorreto, utilizando 'MauticPlugin' em vez de 'Mautic'. Isso causava uma falha silenciosa no carregamento do plugin.

Esta correção atualiza o namespace para o valor correto, permitindo que o Mautic reconheça e carregue o plugin.